### PR TITLE
fix broken android build due to outdated dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,7 +19,7 @@ rootProject.allprojects {
         google()
         jcenter()
         maven {
-            url 'https://dl.bintray.com/qichuan/maven/'
+            url 'https://jitpack.io'
         }
     }
 }
@@ -44,7 +44,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.zqc.opencc.android.lib:lib-opencc-android:0.8.0@aar"
+    implementation "com.github.qichuan:android-opencc:1.2.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.10"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2"


### PR DESCRIPTION
Seems that threre are something wrong with dl.bintray.com/qichuan/maven

We can't get dependencies from that now. 

I replace it with the guide of [https://github.com/qichuan/android-opencc](url)

It works very well now.