### PR TITLE
Fix NO_BUNDLE error on Swift Package Manager builds (iOS)

### DIFF
--- a/ios/flutter_open_chinese_convert/Sources/flutter_open_chinese_convert/FlutterOpenChineseConvertPlugin.swift
+++ b/ios/flutter_open_chinese_convert/Sources/flutter_open_chinese_convert/FlutterOpenChineseConvertPlugin.swift
@@ -10,17 +10,6 @@ public class FlutterOpenChineseConvertPlugin: NSObject, FlutterPlugin {
         registrar.addMethodCallDelegate(instance, channel: channel)
     }
 
-    lazy var bundle: Bundle? = {
-        let openCCBundle = Bundle(for: ChineseConverter.self)
-        guard
-            let resourceUrl = openCCBundle.url(
-                forResource: "OpenCCDictionary", withExtension: "bundle")
-        else {
-            return nil
-        }
-        return Bundle(url: resourceUrl)
-    }()
-
     func convertOptions(from: String) -> ChineseConverter.Options {
         return switch from {
         case "s2t": [.traditionalize]
@@ -39,13 +28,14 @@ public class FlutterOpenChineseConvertPlugin: NSObject, FlutterPlugin {
         let method = call.method
         switch method {
         case "convert":
-            guard let bundle = self.bundle else {
-                let flutterError = FlutterError(
-                    code: "NO_BUNDLE", message: "The bundle for the plugin does not exist.",
-                    details: nil)
-                result(flutterError)
-                return
-            }
+            // Previously this looked up a bundle named "OpenCCDictionary" via
+            // `Bundle(for: ChineseConverter.self)` before calling `convert`. That
+            // matched CocoaPods' resource_bundle naming, but under Swift Package
+            // Manager the equivalent resource is a differently-named, differently
+            // located bundle (e.g. "SwiftyOpenCC_OpenCC.bundle"), so the lookup
+            // always failed there with a NO_BUNDLE error. It's also unnecessary:
+            // `ChineseConverter(options:)` resolves its own dictionaries via
+            // `Bundle.module` internally, so no bundle needs to be passed in here.
             guard let list = call.arguments as? [Any],
                 list.count >= 3,
                 let text = list[0] as? String,
@@ -59,10 +49,9 @@ public class FlutterOpenChineseConvertPlugin: NSObject, FlutterPlugin {
                 return
             }
             if inBackground {
-                convertInBackground(
-                    text: text, optionString: optionString, bundle: bundle, result: result)
+                convertInBackground(text: text, optionString: optionString, result: result)
             } else {
-                convert(text: text, optionString: optionString, bundle: bundle, result: result)
+                convert(text: text, optionString: optionString, result: result)
             }
         default:
             let flutterError = FlutterError(code: "1", message: "Not supported", details: nil)
@@ -71,7 +60,7 @@ public class FlutterOpenChineseConvertPlugin: NSObject, FlutterPlugin {
     }
 
     func convert(
-        text: String, optionString: String, bundle: Bundle, result: @escaping FlutterResult
+        text: String, optionString: String, result: @escaping FlutterResult
     ) {
         do {
             let options = convertOptions(from: optionString)
@@ -86,7 +75,7 @@ public class FlutterOpenChineseConvertPlugin: NSObject, FlutterPlugin {
     }
 
     func convertInBackground(
-        text: String, optionString: String, bundle: Bundle, result: @escaping FlutterResult
+        text: String, optionString: String, result: @escaping FlutterResult
     ) {
         DispatchQueue.global().async {
             do {


### PR DESCRIPTION
Hi @zonble, thanks so much for maintaining this package — it's been really useful for our project! 🙏

While migrating our app from CocoaPods to Swift Package Manager, we ran into an issue where every call to `convert` on iOS started failing. I dug into it a bit and think I found the cause, so I wanted to share what I found and propose a possible fix — please let me know if I've misread anything!

## Problem

On iOS, when this plugin is resolved via **Swift Package Manager** (ratherthan CocoaPods), every call to `convert`/`convertInBackground` fails with:
> PlatformException(NO_BUNDLE, The bundle for the plugin does not exist., null, null)

This makes the plugin completely unusable for any project that has moved to
SPM-based plugin resolution (which Flutter now supports and, in newer
tooling, defaults to).

## Root cause

`FlutterOpenChineseConvertPlugin.swift` (the SPM target, under
`ios/flutter_open_chinese_convert/Sources/...`) looks up its resource bundle
like this before every conversion:

```swift
lazy var bundle: Bundle? = {
    let openCCBundle = Bundle(for: ChineseConverter.self)
    guard let resourceUrl = openCCBundle.url(
        forResource: "OpenCCDictionary", withExtension: "bundle")
    else { return nil }
    return Bundle(url: resourceUrl)
}()
```
This matches CocoaPods' resource_bundle naming convention for SwiftyOpenCC's dictionary files (a bundle literally named
OpenCCDictionary.bundle, nested inside OpenCC.framework). That's correct for the CocoaPods "legacy" target, but under SPM, the equivalent resource is packaged completely differently — as its own standalone bundle following SPM's  Package}_{Target}.bundle convention (e.g. SwiftyOpenCC_OpenCC.bundle), not nested anywhere and not named  penCCDictionary. The lookup above always returns nil there, so every conversion fails.

The check is also unnecessary for the SPM path: ChineseConverter(options:) already resolves its own dictionaries internally via Bundle.module, so the plugin doesn't need to locate or pass in a bundle at all.

## Fix
Remove the dead bundle lookup/guard and the unused bundle parameter from the SPM target's handle, convert, and  onvertInBackground, and call ChineseConverter(options:) directly.

Scope: only the SPM target 
(ios/flutter_open_chinese_convert/Sources/...) is changed. The CocoaPods ios/legacy/ target is untouched — it uses a  ifferent initializer, ChineseConverter(bundle:option:), which genuinely requires an explicit bundle, so its lookup is correct as-is.

## How to reproduce
1. Create a Flutter iOS project with SPM plugin resolution enabled (flutter config --enable-swift-package-manager, or a Flutter version where it's on by default).
2. Add this plugin and call ChineseConverter.convert(text, S2TWp()).
3. Observe the NO_BUNDLE error on every call.

## Verification
Reproduced against a production Flutter app that recently migrated from CocoaPods to SPM — confirmed NO_BUNDLE was thrown 100% of the time before this fix. Applied this fix via a dependency_overrides git dependency pointing at this branch, rebuilt, and confirmed conversion now succeeds and renders correctly end-to-end in the app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Chinese text conversion when the plugin is installed through Swift Package Manager.
  * Conversion no longer fails with an “OpenCCDictionary” bundle error.
  * Background and standard conversion now consistently locate the required dictionaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->